### PR TITLE
Refactor: SCSS

### DIFF
--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -28,7 +28,22 @@ const config = {
     module: {
         rules: [
             { test: /\.md$/, use: ['raw-loader'] },
-            { test: /\.scss$/, use: ['style-loader', 'css-loader', 'sass-loader'] },
+            {
+                test: /\.scss$/,
+                use: [
+                  'style-loader',
+                  {
+                    loader: 'css-loader',
+                    options: {
+                      importLoaders: 1,
+                      modules: {
+                        mode: 'icss', // Enable ICSS (Interoperable CSS)
+                      },
+                    },
+                  },
+                  'sass-loader',
+                ],
+            },
             {
                 test: /\.ts$/,
                 exclude: /node_modules/,

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,3 +1,159 @@
+/**
+ * Flatten a map or list into a string
+ * @param {any} $value - The value to flatten
+ * @returns {string} The flattened value
+ */
+@function flatten($value) {
+    @if type-of($value) == 'map' {
+        $result: "";
+        @each $key, $val in $value {
+            $flattened-val: flatten($val);
+            $result: "#{$result}#{$key}: #{$flattened-val}; ";
+        }
+        @return $result;
+    } @else if type-of($value) == 'list' {
+        $result: "";
+        @each $item in $value {
+            $flattened-item: flatten($item);
+            $result: "#{$result}#{$flattened-item}, ";
+        }
+        @return $result;
+    } @else {
+        @return $value;
+    }
+}
+
+/**
+ * Export a map as CSS variables
+ * @param {map} $map - The map to export
+ * @param {string} $name - The name of the export
+ */
+@mixin export-map($map, $name) {
+    :export {
+        #{$name}: "#{flatten($map)}";
+    }
+}
+
+/**
+ * Color variables
+ */
+$mynah-color-text: (
+    'default': var(--vscode-foreground),
+    'alternate': var(--mynah-color-button-reverse),
+    'strong': var(--vscode-input-foreground),
+    'weak': var(--vscode-disabledForeground),
+    'link': var(--vscode-textLink-foreground),
+    'input': var(--vscode-input-foreground)
+);
+
+/**
+ * Statuses
+ */
+$mynah-statuses: ("success", "error", "warning", "info");
+
+/**
+ * Status variables
+ */
+$mynah-status-colors: (
+    'info': #0971d3,
+    'success': #037f03,
+    'warning': #b2911c,
+    'error': #d91515
+);
+
+/**
+ * Font variables
+ */
+$mynah-font-sizes: (
+    'xxsmall': 0.75rem,
+    'xsmall': 0.85rem,
+    'small': 0.95rem,
+    'medium': 1rem,
+    'large': 1.125rem
+);
+
+/**
+ * Padding sizes
+ */
+$mynah-padding-sizes: (
+  'none': 0,
+  'small': 1,
+  'medium': 3,
+  'large': 5,
+);
+
+/**
+ * Transition variables
+ */
+$mynah-transitions: (
+    'bottom-panel': (850, cubic-bezier(0.25, 1, 0, 1)),
+    'very-short': (600, cubic-bezier(0.25, 1, 0, 1)),
+    'very-long': (1650, cubic-bezier(0.25, 1, 0, 1)),
+    'short': (550, cubic-bezier(0.85, 0.15, 0, 1)),
+    'short-rev': (580, cubic-bezier(0.35, 1, 0, 1))
+);
+
+/**
+ * Syntax highlighting variables
+ */
+ $mynah-syntax-colors: (
+    'bg': var(--vscode-terminal-dropBackground),
+    'variable': var(--vscode-debugTokenExpression-name),
+    'function': var(--vscode-gitDecoration-modifiedResourceForeground),
+    'operator': var(--vscode-debugTokenExpression-name),
+    'attr-value': var(--vscode-debugIcon-stepBackForeground),
+    'attr': var(--vscode-debugTokenExpression-string),
+    'property': var(--vscode-terminal-ansiCyan),
+    'comment': var(--vscode-debugConsole-sourceForeground),
+    'code': var(--vscode-editor-foreground, var(--mynah-color-text-default, inherit))
+);
+
+/**
+ * Token styles
+ */
+ $mynah-token-styles: (
+    'comments': (color: var(--mynah-color-syntax-comment)),
+    'punctuation': (color: currentColor),
+    'namespace': (opacity: 0.7),
+    'properties': (color: var(--mynah-color-syntax-property)),
+    'attributes': (color: var(--mynah-color-syntax-attr)),
+    'operators': (color: var(--mynah-color-syntax-operator)),
+    'attr-values': (color: var(--mynah-color-syntax-attr-value)),
+    'functions': (color: var(--mynah-color-syntax-function), font-weight: 500),
+    'variables': (color: var(--mynah-color-syntax-variable), font-weight: 500),
+    'bold': (font-weight: bold),
+    'italic': (font-style: italic),
+    'entity': (cursor: help)
+);
+
+/**
+ * Syntax token styles
+ */
+$mynah-syntax-token-styles: (
+    'comments': (comment, prolog, doctype, cdata),
+    'punctuation': (punctuation),
+    'namespace': (namespace),
+    'properties': (property, tag, boolean, number, constant, symbol, inserted),
+    'attributes': (selector, attr-name, string, char, builtin, deleted),
+    'operators': (operator, entity, url),
+    'attr-values': (atrule, attr-value, class-name, keyword),
+    'functions': (function),
+    'variables': (regex, important, variable),
+    'bold': (important, bold),
+    'italic': (italic),
+    'entity': (entity)
+);
+
+@include export-map($mynah-color-text, 'mynah-color-text');
+@include export-map($mynah-statuses, 'mynah-statuses');
+@include export-map($mynah-syntax-colors, 'mynah-syntax-colors');
+@include export-map($mynah-status-colors, 'mynah-status-colors');
+@include export-map($mynah-font-sizes, 'mynah-font-sizes');
+@include export-map($mynah-padding-sizes, 'mynah-padding-sizes');
+@include export-map($mynah-transitions, 'mynah-transitions');
+@include export-map($mynah-syntax-token-styles, 'mynah-syntax-token-styles');
+
+
 :root {
     --mynah-font-family: var(--vscode-font-family), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
         "Amazon Ember", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
@@ -18,18 +174,6 @@
     --mynah-button-border-width: 1px;
     --mynah-border-width: 1px;
 
-    /**
-     * Color variables
-     */
-    $mynah-color-text: (
-        'default': var(--vscode-foreground),
-        'alternate': var(--mynah-color-button-reverse),
-        'strong': var(--vscode-input-foreground),
-        'weak': var(--vscode-disabledForeground),
-        'link': var(--vscode-textLink-foreground),
-        'input': var(--vscode-input-foreground)
-    );
-
     @each $name, $value in $mynah-color-text {
         --mynah-color-text-#{$name}: #{$value};
     }
@@ -46,22 +190,6 @@
     --mynah-color-toggle: var(--vscode-sideBar-background);
     --mynah-color-toggle-reverse: rgba(0, 0, 0, 0.5);
 
-
-    /**
-     * Syntax highlighting variables
-     */
-     $mynah-syntax-colors: (
-        'bg': var(--vscode-terminal-dropBackground),
-        'variable': var(--vscode-debugTokenExpression-name),
-        'function': var(--vscode-gitDecoration-modifiedResourceForeground),
-        'operator': var(--vscode-debugTokenExpression-name),
-        'attr-value': var(--vscode-debugIcon-stepBackForeground),
-        'attr': var(--vscode-debugTokenExpression-string),
-        'property': var(--vscode-terminal-ansiCyan),
-        'comment': var(--vscode-debugConsole-sourceForeground),
-        'code': var(--vscode-editor-foreground, var(--mynah-color-text-default, inherit))
-    );
-
     @each $name, $value in $mynah-syntax-colors {
         --mynah-color-syntax-#{$name}: #{$value};
     }
@@ -69,15 +197,6 @@
     --mynah-syntax-code-font-family: var(--vscode-editor-font-family);
     --mynah-syntax-code-font-size: var(--vscode-editor-font-size, var(--mynah-font-size-medium));
 
-    /**
-     * Status variables
-     */
-    $mynah-status-colors: (
-        'info': #0971d3,
-        'success': #037f03,
-        'warning': #b2911c,
-        'error': #d91515
-    );
 
     @each $name, $value in $mynah-status-colors {
         --mynah-color-status-#{$name}: #{$value};
@@ -96,17 +215,6 @@
     --mynah-shadow-card: none; //0 10px 20px -15px rgba(0, 0, 0, 0.25);
     --mynah-shadow-overlay: 0 0px 15px -5px rgba(0, 0, 0, 0.4);
 
-    /**
-     * Font variables
-     */
-    $mynah-font-sizes: (
-        'xxsmall': 0.75rem,
-        'xsmall': 0.85rem,
-        'small': 0.95rem,
-        'medium': 1rem,
-        'large': 1.125rem
-    );
-
     @each $name, $value in $mynah-font-sizes {
         --mynah-font-size-#{$name}: #{$value};
     }
@@ -119,17 +227,6 @@
     --mynah-card-radius-corner: 0;
     --mynah-button-radius: var(--mynah-sizing-1);
 
-
-    /**
-     * Transition variables
-     */
-    $mynah-transitions: (
-        'bottom-panel': (850, cubic-bezier(0.25, 1, 0, 1)),
-        'very-short': (600, cubic-bezier(0.25, 1, 0, 1)),
-        'very-long': (1650, cubic-bezier(0.25, 1, 0, 1)),
-        'short': (550, cubic-bezier(0.85, 0.15, 0, 1)),
-        'short-rev': (580, cubic-bezier(0.35, 1, 0, 1))
-    );
     @each $name, $values in $mynah-transitions {
         @include mynah-transition($name, nth($values, 1), nth($values, 2));
     }

--- a/src/styles/components/_icon.scss
+++ b/src/styles/components/_icon.scss
@@ -6,14 +6,11 @@
     height: 1em;
     font-variant: normal;
     text-transform: none;
-    -webkit-mask-size: 100%;
-    mask-size: 100%;
-    -webkit-mask-position: center center;
-    mask-position: center center;
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
+    -webkit-mask: center/100% no-repeat;
+    mask: center/100% no-repeat;
     color: inherit;
     background-color: currentColor;
+
     > span {
         display: none;
     }

--- a/src/styles/components/_main-container.scss
+++ b/src/styles/components/_main-container.scss
@@ -25,13 +25,10 @@ $smoothduration: 400ms;
         }
     }
 
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        font-weight: 600;
+    @for $i from 1 through 6 {
+        h#{$i} {
+            font-weight: 600;
+        }
     }
 
     ::-webkit-scrollbar {

--- a/src/styles/components/_notification.scss
+++ b/src/styles/components/_notification.scss
@@ -17,14 +17,10 @@
             &ok-circled {
                 color: var(--mynah-color-status-success);
             }
-            &info {
-                color: var(--mynah-color-status-info);
-            }
-            &warning {
-                color: var(--mynah-color-status-warning);
-            }
-            &error {
-                color: var(--mynah-color-status-error);
+            @each $status in info warning error {
+                &#{$status} {
+                    color: var(--mynah-color-status-#{$status});
+                }
             }
         }
     }

--- a/src/styles/components/_source-link-header.scss
+++ b/src/styles/components/_source-link-header.scss
@@ -111,10 +111,11 @@
                 }
             }
             > span {
-                &:not(:last-child):after {
-                    content: ">";
-                    margin-left: var(--mynah-sizing-1);
-                    margin-right: var(--mynah-sizing-1);
+                &:not(:last-child) {
+                    &:after {
+                        content: ">";
+                        margin: 0 var(--mynah-sizing-1);
+                    }
                 }
                 &:nth-child(3) ~ span:not(:last-child) {
                     display: none;

--- a/src/styles/components/_syntax-highlighter.scss
+++ b/src/styles/components/_syntax-highlighter.scss
@@ -156,77 +156,19 @@ pre > code.diff-highlight .token.inserted:not(.prefix) {
             background: #b3d4fc;
         }
 
-        .token.comment,
-        .token.prolog,
-        .token.doctype,
-        .token.cdata {
-            color: var(--mynah-color-syntax-comment);
-        }
-
-        .token.punctuation {
-            color: currentColor;
-        }
-
-        .token.namespace {
-            opacity: 0.7;
-        }
-
-        .token.property,
-        .token.tag,
-        .token.boolean,
-        .token.number,
-        .token.constant,
-        .token.symbol,
-        .token.inserted {
-            color: var(--mynah-color-syntax-property);
-        }
-
-        .token.selector,
-        .token.attr-name,
-        .token.string,
-        .token.char,
-        .token.builtin,
-        .token.deleted {
-            color: var(--mynah-color-syntax-attr);
-        }
-
-        .token.operator,
-        .token.entity,
-        .token.url,
-        .language-css .token.string,
-        .style .token.string {
-            color: var(--mynah-color-syntax-operator);
-        }
-
-        .token.atrule,
-        .token.attr-value,
-        .token.class-name,
-        .token.keyword {
-            color: var(--mynah-color-syntax-attr-value);
-        }
-
-        .token.function {
-            color: var(--mynah-color-syntax-function);
-            font-weight: 500;
-        }
-
-        .token.regex,
-        .token.important,
-        .token.variable {
-            color: var(--mynah-color-syntax-variable);
-            font-weight: 500;
-        }
-
-        .token.important,
-        .token.bold {
-            font-weight: bold;
-        }
-        .token.italic {
-            font-style: italic;
-        }
-
-        .token.entity {
-            cursor: help;
+        /**
+        * Loop through each style category and its corresponding tokens in $mynah-syntax-token-styles.
+        * For each token, apply the styles defined in $mynah-token-styles based on the style category.
+        * This replaces individual style definitions for each token class and makes the SCSS more maintainable.
+        */
+        @each $style, $tokens in $mynah-syntax-token-styles {
+            @each $token in $tokens {
+                .token.#{$token} {
+                    @each $property, $value in map-get($mynah-token-styles, $style) {
+                        #{$property}: #{$value};
+                    }
+                }
+            }
         }
 
         &.line-numbers {

--- a/src/styles/components/card/_card.scss
+++ b/src/styles/components/card/_card.scss
@@ -19,18 +19,13 @@
   }
 
   &.padding {
-    &-none {
-      padding: 0;
-      border-radius: 0;
-    }
-    &-small {
-      padding: var(--mynah-sizing-1);
-    }
-    &-medium {
-      padding: var(--mynah-sizing-3);
-    }
-    &-large {
-      padding: var(--mynah-sizing-5);
+    @each $size, $padding in $mynah-padding-sizes {
+      &-#{$size} {
+        padding: var(--mynah-sizing-#{$padding});
+        @if $size == 'none' {
+          border-radius: 0;
+        }
+      }
     }
   }
   &.background {

--- a/src/styles/components/chat/_chat-item-card.scss
+++ b/src/styles/components/chat/_chat-item-card.scss
@@ -10,35 +10,13 @@
     gap: var(--mynah-sizing-4);
 
     &-status {
-        &-success {
-            > .mynah-card {
-                border-color: var(--mynah-color-status-success);
-                > .mynah-chat-item-card-icon {
-                    color: var(--mynah-color-status-success);
-                }
-            }
-        }
-        &-error {
-            > .mynah-card {
-                border-color: var(--mynah-color-status-error);
-                > .mynah-chat-item-card-icon {
-                    color: var(--mynah-color-status-error);
-                }
-            }
-        }
-        &-warning {
-            > .mynah-card {
-                border-color: var(--mynah-color-status-warning);
-                > .mynah-chat-item-card-icon {
-                    color: var(--mynah-color-status-warning);
-                }
-            }
-        }
-        &-info {
-            > .mynah-card {
-                border-color: var(--mynah-color-status-info);
-                > .mynah-chat-item-card-icon {
-                    color: var(--mynah-color-status-info);
+        @each $status in $mynah-statuses {
+            &-#{$status} {
+                > .mynah-card {
+                    border-color: var(--mynah-color-status-#{$status});
+                    > .mynah-chat-item-card-icon {
+                        color: var(--mynah-color-status-#{$status});
+                    }
                 }
             }
         }
@@ -141,12 +119,12 @@
                 > .mynah-syntax-highlighter {
                     filter: contrast(1.15) brightness(0.85);
                 }
-                > h1,
-                > h2,
-                > h3,
-                > h4 {
-                    &:first-child {
-                        margin-top: 0;
+
+                @for $i from 1 through 4 {
+                    h#{$i} {
+                        &:first-child {
+                            margin-top: 0;
+                        }
                     }
                 }
             }
@@ -211,17 +189,10 @@
             opacity: 0.75;
         }
         &-status {
-            &-success {
-                color: var(--mynah-color-status-success);
-            }
-            &-error {
-                color: var(--mynah-color-status-error);
-            }
-            &-warning {
-                color: var(--mynah-color-status-warning);
-            }
-            &-info {
-                color: var(--mynah-color-status-info);
+            @each $status in $mynah-statuses {
+                &-#{$status} {
+                    color: var(--mynah-color-status-#{$status});
+                }
             }
         }
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,22 @@ const config = {
   },
   module: {
     rules: [
-      { test: /\.scss$/, use: ['style-loader', 'css-loader', 'sass-loader'] },
+      {
+        test: /\.scss$/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              importLoaders: 1,
+              modules: {
+                mode: 'icss', // Enable ICSS (Interoperable CSS)
+              },
+            },
+          },
+          'sass-loader',
+        ],
+      },
       {
         test: /\.ts$/,
         exclude: [/node_modules/, /.\/example/],


### PR DESCRIPTION
## Problem

* SCSS loader module did not support SCSS `:export` feature which meant we need to `@include` and maps or arrays created on the root
* The above also allows for not having to create array and maps or anything else across nested `_` SCSS files
* Multiple redundancies (ex: `.token....` had way too many declarations which made it look lik CSS rather than levearging the super awesome thing that SCSS as a preprocessor was built for

## Solution

* Added `icss` mode to both `webpack.config.js` files
  * this was test both in `/examples` and `root` folder with `npm run watch` and build
* Added some new `@mixins`
  * `export-map` for exporting `:export` feature of SCSS
* Added `@function` `flatten` because we can't have nested unnamed function in SCSS nested in `@mixins`
* Reduced many multiple style class declaration with loop `@each` `@for`
* Create some array and maps, some multi dimensional in `_variables`
  * `$mynah-color-text`
  * `$mynah-statuses`
  * `$mynah-status-colors`
  * `$mynah-font-sizes`
  * `$mynah-padding-sizes`
  * `$mynah-transitions`
  * `$mynah-syntax-colors`
  * `$mynah-token-styles`
  * `$mynah-syntax-token-styles`
  
 of particular note is `$mynah-syntax-token-styles` as through it i was able to remove **70 lines** of `.token` stuff with
 
 ```
         @each $style, $tokens in $mynah-syntax-token-styles {
            @each $token in $tokens {
                .token.#{$token} {
                    @each $property, $value in map-get($mynah-token-styles, $style) {
                        #{$property}: #{$value};
                    }
                }
            }
        }
```

this was fun         

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
